### PR TITLE
fix half circle clipping issues on iOS and android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   leftWrap: {
+    overflow: 'hidden',
     position: 'absolute',
     top: 0,
   },
@@ -89,14 +90,14 @@ export default class PercentageCircle extends Component {
     }
   }
 
-  renderHalfCircle(rotateDegrees, halfCircleStyles) {
+  renderHalfCircle(left, rotateDegrees, halfCircleStyles) {
     const { radius, color } = this.props
     return (
       <View
         style={[
           styles.leftWrap,
           {
-            left: radius,
+            left: left,
             width: radius,
             height: radius * 2,
           },
@@ -106,7 +107,7 @@ export default class PercentageCircle extends Component {
           style={[
             styles.halfCircle,
             {
-              left: -radius,
+              left: -left,
               width: radius,
               height: radius * 2,
               borderRadius: radius,
@@ -162,8 +163,8 @@ export default class PercentageCircle extends Component {
           },
         ]}
       >
-        {this.renderHalfCircle(halfCircle1Degree)}
-        {this.renderHalfCircle(halfCircle2Degree, halfCircle2Styles)}
+        {this.renderHalfCircle(this.props.radius, halfCircle1Degree)}
+        {this.renderHalfCircle(0, halfCircle2Degree, halfCircle2Styles)}
         {this.renderInnerCircle()}
       </View>
     )


### PR DESCRIPTION
some clipping issues on iOS and android are now fix:

<img width="278" alt="screen shot 2017-09-07 at 08 36 15" src="https://user-images.githubusercontent.com/13063075/30151530-bbe2c4b4-93a7-11e7-8f39-96e013f8bcfe.png">
<img width="267" alt="screen shot 2017-09-07 at 08 36 30" src="https://user-images.githubusercontent.com/13063075/30151535-bfa1ed28-93a7-11e7-9f34-6f96ec510ba2.png">