### PR TITLE
Fix bug when changing shadowColor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,8 +86,8 @@ export default class PercentageCircle extends Component {
         // when the second half circle is not needed, we need it to cover
         // the negative degrees of the first circle
         backgroundColor: needHalfCircle2
-          ? this.props.color
-          : this.props.shadowColor,
+          ? props.color
+          : props.shadowColor,
       },
     }
   }


### PR DESCRIPTION
I was changing the shadowColor according to whether the enclosing item was selected by the user, and noticed that after unselecting the item, the left half of the circle got painted with the _previous_ shadowColor.

This should fix that.