### PR TITLE
Fix overflowing halfCircleRender on IOS devices

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ export default class PercentageCircle extends Component {
               width: radius,
               height: radius * 2,
               borderRadius: radius,
+              overflow: 'hidden',
               transform: [
                 { translateX: radius / 2 },
                 { rotate: `${rotateDegrees}deg` },


### PR DESCRIPTION
Hi, my Pull Request for HacktoberFest : )
Back story:
I really needed a Circle Progress component for React-Native and I really liked this one, as this one is not depending on any other 3rd libraries like `react-native-svg`.
So I went ahead and installed that, imported and was happyfully using that Component for couple of days until I tried my app on IOS based devices.

My Environment:
React Native: 0.57
Android Device: Huawei P8 Lite, Android 6.0
IOS Device: Emulator IOS / IPhone 6S IOS: 11.4
This is how it was looking (example from README) on Android - totally fine:  
![obraz](https://user-images.githubusercontent.com/11317951/47604872-6b024980-d9ff-11e8-8bfb-c331ca2f0db0.png)

And this is how the same code was looking on IOS Device:  
![simulator screen shot - iphone 6s - 2018-10-27 at 15 52 41](https://user-images.githubusercontent.com/11317951/47604935-5f635280-da00-11e8-86bc-b4d5cd4c432b.png)

The fix is simply to hide overflow on halfCircles, inspired by this issue:  
https://github.com/facebook/react-native/issues/13760

After applying the fix, this is how the same view looks on Android (exactly the same, as this is only broken on IOS):  
![obraz](https://user-images.githubusercontent.com/11317951/47604962-b701be00-da00-11e8-8c95-746c6c55d4b4.png)  

And IOS device:  
![simulator screen shot - iphone 6s - 2018-10-27 at 15 57 05](https://user-images.githubusercontent.com/11317951/47604982-f7613c00-da00-11e8-9627-0fa2425441c6.png)

Let me know if you have any questions or anything should be changed.