### PR TITLE
Add support for new reacts lifecycle methods and remove deprecated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,16 +57,15 @@ export default class PercentageCircle extends Component {
     containerStyle: null,
   };
 
-  constructor(props) {
-    super(props)
-    this.state = this.getInitialStateFromProps(props)
+  state = {
+    halfCircle1Degree: 0,
+    halfCircle2Degree: 0,
+    halfCircle2Styles: {
+      backgroundColor: this.props.shadowColor
+    }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState(this.getInitialStateFromProps(nextProps))
-  }
-
-  getInitialStateFromProps(props) {
+  static getDerivedStateFromProps(props) {
     const percent = Math.max(Math.min(100, props.percent), 0)
     const needHalfCircle2 = percent > 50
     let halfCircle1Degree


### PR DESCRIPTION
React is deprecating `componentWillReceiveProps` and adding static method `getDerivedStateFromProps`.

I suggest making a major version bump since new methods are not available in versions lower than 16.3 and deprecated methods will be completely removed in 17.0.

More info: https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops